### PR TITLE
Add mdv to pretty print card markdown in terminal

### DIFF
--- a/kaori/plugins/gacha/bin/simulator.py
+++ b/kaori/plugins/gacha/bin/simulator.py
@@ -7,6 +7,14 @@ from typing import Optional, List
 from kaori.plugins.gacha.engine.test import run_card_simulator, run_battle_simulator
 from kaori.plugins.gacha.engine.test.battle_simulator import BattleResult
 
+card_command = argparse.ArgumentParser(description='Simulate cards and their values.')
+card_command.add_argument('--raw',
+                          '-r',
+                          action='store_true',
+                          dest='raw',
+                          default=False,
+                          help='print output in raw markdown')
+
 battle_command = argparse.ArgumentParser(description='Process some integers.')
 battle_command.add_argument('card_A',
                             metavar='card_name',
@@ -40,7 +48,8 @@ def main():
     command = sys.argv[1]
 
     if command == 'cards':
-        return run_card_simulator()
+        args = card_command.parse_args(sys.argv[2:])
+        return run_card_simulator(args.raw)
 
     if command == 'battle':
         args = battle_command.parse_args(sys.argv[2:])

--- a/kaori/plugins/gacha/engine/test/card_simulator.py
+++ b/kaori/plugins/gacha/engine/test/card_simulator.py
@@ -63,18 +63,24 @@ def run_card_simulator(raw=False):
         return print(x, file=out) if x else print(file=out)
 
     p(f"## Simulator Results: {arrow.utcnow()}")
+    p()
     p(f"### Game Facts")
     p(f"{combat_strat.__class__.__name__} combat strategy")
     p(trim_doc(combat_strat.__doc__))
+    p()
     p(f"Nature values range from {combat_strat.min_nature_value} to {combat_strat.max_nature_value}")
+    p()
     p(f"### Cards")
+    p()
     for name, cards in card_groups.items():
-        p(f"<details><summary>{name}</summary>" if raw else "")
+        p(f"<details><summary>{name}</summary>" if raw else f"### {name}")
+        p()
         card: Card
         for card in cards:
             p(card.to_markdown())
         p(f"</details>" if raw else "")
-
+        p()
+        
     if raw:
         print(out.getvalue())
     else:

--- a/kaori/plugins/gacha/engine/test/card_simulator.py
+++ b/kaori/plugins/gacha/engine/test/card_simulator.py
@@ -1,4 +1,5 @@
 import arrow
+import mdv
 
 from .balanced_cards import *
 from .dmg_cards import *
@@ -8,7 +9,7 @@ from .. import Card
 from ..utils import trim_doc
 
 
-def run_card_simulator():
+def run_card_simulator(raw=False):
     card_groups = {
         'Baselines': [
             hp_no_invest,
@@ -54,22 +55,23 @@ def run_card_simulator():
         card: Card
         for card in cards:
             card.is_valid_card()
-
-    print(f"## Simulator Results: {arrow.utcnow()}")
-    print()
-    print(f"### Game Facts")
-    print(f"{combat_strat.__class__.__name__} combat strategy")
-    print(trim_doc(combat_strat.__doc__))
-    print()
-    print(f"Nature values range from {combat_strat.min_nature_value} to {combat_strat.max_nature_value}")
-    print()
-    print(f"### Cards")
-    print()
+    output_strs = []
+    output_strs.append(f"## Simulator Results: {arrow.utcnow()}")
+    output_strs.append(f"### Game Facts")
+    output_strs.append(f"{combat_strat.__class__.__name__} combat strategy")
+    output_strs.append(trim_doc(combat_strat.__doc__))
+    output_strs.append(f"Nature values range from {combat_strat.min_nature_value} to {combat_strat.max_nature_value}")
+    output_strs.append(f"### Cards")
     for name, cards in card_groups.items():
-        print(f"<details><summary>{name}</summary>")
-        print()
+        output_strs.append(f"<details><summary>{name}</summary>" if raw else "")
         card: Card
         for card in cards:
-            print(card.to_markdown())
-        print(f"</details>")
-        print()
+            output_strs.append(card.to_markdown())
+        output_strs.append(f"</details>" if raw else "")
+
+    output = "\n".join(output_strs)
+    if raw:
+        print(output)
+    else:
+        formatted = mdv.main(output, theme="960.847")
+        print(formatted)

--- a/kaori/plugins/gacha/engine/test/card_simulator.py
+++ b/kaori/plugins/gacha/engine/test/card_simulator.py
@@ -1,3 +1,4 @@
+from io import StringIO
 import arrow
 import mdv
 
@@ -55,23 +56,26 @@ def run_card_simulator(raw=False):
         card: Card
         for card in cards:
             card.is_valid_card()
-    output_strs = []
-    output_strs.append(f"## Simulator Results: {arrow.utcnow()}")
-    output_strs.append(f"### Game Facts")
-    output_strs.append(f"{combat_strat.__class__.__name__} combat strategy")
-    output_strs.append(trim_doc(combat_strat.__doc__))
-    output_strs.append(f"Nature values range from {combat_strat.min_nature_value} to {combat_strat.max_nature_value}")
-    output_strs.append(f"### Cards")
+
+    out = StringIO()
+
+    def p(x=None):
+        return print(x, file=out) if x else print(file=out)
+
+    p(f"## Simulator Results: {arrow.utcnow()}")
+    p(f"### Game Facts")
+    p(f"{combat_strat.__class__.__name__} combat strategy")
+    p(trim_doc(combat_strat.__doc__))
+    p(f"Nature values range from {combat_strat.min_nature_value} to {combat_strat.max_nature_value}")
+    p(f"### Cards")
     for name, cards in card_groups.items():
-        output_strs.append(f"<details><summary>{name}</summary>" if raw else "")
+        p(f"<details><summary>{name}</summary>" if raw else "")
         card: Card
         for card in cards:
-            output_strs.append(card.to_markdown())
-        output_strs.append(f"</details>" if raw else "")
+            p(card.to_markdown())
+        p(f"</details>" if raw else "")
 
-    output = "\n".join(output_strs)
     if raw:
-        print(output)
+        print(out.getvalue())
     else:
-        formatted = mdv.main(output, theme="960.847")
-        print(formatted)
+        print(mdv.main(out.getvalue(), theme="960.847"))

--- a/poetry.lock
+++ b/poetry.lock
@@ -260,12 +260,42 @@ version = "1.0.14"
 MarkupSafe = ">=0.9.2"
 
 [[package]]
+category = "dev"
+description = "Python implementation of Markdown."
+name = "markdown"
+optional = false
+python-versions = ">=3.5"
+version = "3.2.1"
+
+[package.dependencies]
+setuptools = ">=36"
+
+[package.extras]
+testing = ["coverage", "pyyaml"]
+
+[[package]]
 category = "main"
 description = "Safely add untrusted strings to HTML/XML markup."
 name = "markupsafe"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 version = "1.1.1"
+
+[[package]]
+category = "dev"
+description = "Terminal Markdown Viewer"
+name = "mdv"
+optional = false
+python-versions = "*"
+version = "1.7.4"
+
+[package.dependencies]
+markdown = "*"
+pygments = "*"
+tabulate = "*"
+
+[package.extras]
+yaml = ["pyyaml"]
 
 [[package]]
 category = "dev"
@@ -352,11 +382,19 @@ version = "1.8.0"
 [[package]]
 category = "main"
 description = "C parser in Python"
-marker = "sys_platform == \"win32\" and platform_python_implementation == \"CPython\" and (sys_platform == \"win32\" and platform_python_implementation == \"CPython\")"
+marker = "sys_platform == \"win32\" and platform_python_implementation == \"CPython\""
 name = "pycparser"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.19"
+
+[[package]]
+category = "dev"
+description = "Pygments is a syntax highlighting package written in Python."
+name = "pygments"
+optional = false
+python-versions = ">=3.5"
+version = "2.6.1"
 
 [[package]]
 category = "dev"
@@ -532,6 +570,17 @@ postgresql_psycopg2cffi = ["psycopg2cffi"]
 pymysql = ["pymysql"]
 
 [[package]]
+category = "dev"
+description = "Pretty-print tabular data"
+name = "tabulate"
+optional = false
+python-versions = "*"
+version = "0.8.7"
+
+[package.extras]
+widechars = ["wcwidth"]
+
+[[package]]
 category = "main"
 description = "Ultra fast JSON encoder and decoder for Python"
 name = "ujson"
@@ -609,7 +658,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "58b68cab77e917b0443292175ca05193b01000224c3a427b1ed53f7fb2d6a5e6"
+content-hash = "9c62157d181bdeae51517c4a75f059fa0283869460c67ee5ae818d236e93a0bd"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -779,6 +828,10 @@ jmespath = [
 mako = [
     {file = "Mako-1.0.14.tar.gz", hash = "sha256:f5a642d8c5699269ab62a68b296ff990767eb120f51e2e8f3d6afb16bdb57f4b"},
 ]
+markdown = [
+    {file = "Markdown-3.2.1-py2.py3-none-any.whl", hash = "sha256:e4795399163109457d4c5af2183fbe6b60326c17cfdf25ce6e7474c6624f725d"},
+    {file = "Markdown-3.2.1.tar.gz", hash = "sha256:90fee683eeabe1a92e149f7ba74e5ccdc81cd397bd6c516d93a8da0ef90b6902"},
+]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
     {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
@@ -813,6 +866,9 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+]
+mdv = [
+    {file = "mdv-1.7.4.tar.gz", hash = "sha256:1534f477c85d580352c82141436f6fdba79d329af8a5ee7e329fea14424a660d"},
 ]
 more-itertools = [
     {file = "more-itertools-7.2.0.tar.gz", hash = "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832"},
@@ -873,6 +929,10 @@ py = [
 pycparser = [
     {file = "pycparser-2.19.tar.gz", hash = "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"},
 ]
+pygments = [
+    {file = "Pygments-2.6.1-py3-none-any.whl", hash = "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"},
+    {file = "Pygments-2.6.1.tar.gz", hash = "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"},
+]
 pyparsing = [
     {file = "pyparsing-2.4.2-py2.py3-none-any.whl", hash = "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"},
     {file = "pyparsing-2.4.2.tar.gz", hash = "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80"},
@@ -931,6 +991,10 @@ slackclient = [
 slacktools = []
 sqlalchemy = [
     {file = "SQLAlchemy-1.3.6.tar.gz", hash = "sha256:217e7fc52199a05851eee9b6a0883190743c4fb9c8ac4313ccfceaffd852b0ff"},
+]
+tabulate = [
+    {file = "tabulate-0.8.7-py3-none-any.whl", hash = "sha256:ac64cb76d53b1231d364babcd72abbb16855adac7de6665122f97b593f1eb2ba"},
+    {file = "tabulate-0.8.7.tar.gz", hash = "sha256:db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007"},
 ]
 ujson = [
     {file = "ujson-1.35.tar.gz", hash = "sha256:f66073e5506e91d204ab0c614a148d5aa938bdbf104751be66f8ad7a222f5f86"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ raven = "^6.10"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.1"
+mdv = "^1.7.4"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
- Add [mdv](https://github.com/axiros/terminal_markdown_viewer) to pretty print card markdown
- Add `--raw` flag to card simulator command to allow raw markdown printing

mdv didn't handle the HTML parts correctly so I just omit it from the formatted output. It's still there in the raw output.