### PR TITLE
dmg during crit = (dmg + cursed) * crit_multiplier

### DIFF
--- a/kaori/plugins/gacha/engine/core/card.py
+++ b/kaori/plugins/gacha/engine/core/card.py
@@ -161,7 +161,10 @@ class Card:
                       target: Card,
                       crit_multiplier: int = 1,
                       debug: bool = False) -> int:
-        apply_crit = self.dmg * crit_multiplier
+        dmg = self.dmg
+        if crit_multiplier != 1:
+            dmg = self.dmg + self.cursed
+        apply_crit = dmg * crit_multiplier
         apply_armor = apply_crit - target.armor
         rounded = round(apply_armor)
         dmg = max(0, rounded)


### PR DESCRIPTION
Previously crits were just `dmg * crit_multiplier`. This ran into a problem in the following situation:

- horny: 1
- cursed: 7

So in this situation you have a card that has an exceptional cursed value. This is probably a high tier rarity card. The behavior is as such:

- regular dmg is `low as heck`, close to the lowest value in the game
- crit damage is `(low as heck) * crit_multiplier` which is basically the same as the base damage

Well that sucks. You were better off just investing in something other than cursed. So what about:

`(dmg + cursed) * crit_multiplier`

- regular dmg is `low as heck`, close to the lowest value in the game
- crit damage is `(low as heck) + (number close to 11) * crit_multiplier`. Now you will be hitting pretty hard, just not all the time.