### PR TITLE
Better gweb volume mount convention

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,9 @@ services:
 
   gweb:
     <<: *test
-    working_dir: /app/kaori/plugins/gacha/static
+    working_dir: /www
+    volumes:
+      - ./kaori/plugins/gacha/static:/www:ro
     command: ["python", "-m", "http.server"]
     ports:
       - 8080:8000


### PR DESCRIPTION
We only need to mount this one folder, don't mount whole project. Don't need write access either.

I haven't tested this for perf or anything but I assume mounting less is always better for macbros and such?