### PR TITLE
DRY config system and add tests-specific config

### DIFF
--- a/config/kaori.py
+++ b/config/kaori.py
@@ -1,19 +1,24 @@
 import os
 
-API_KEY = os.environ.get('KIZUNA_API_KEY', None)
-DATABASE_URL = os.environ.get('DATABASE_URL', 'postgresql://kaori:kaori@db:5432/kaori')
-KIZUNA_ENV = os.environ.get('KIZUNA_ENV', 'development')
-KIZUNA_HOME_CHANNEL = os.environ.get('KIZUNA_HOME_CHANNEL', '#kaori-home')
-MAIN_CHANNEL = os.environ.get('MAIN_CHANNEL', '#banter')
-SENTRY_URL = os.environ.get('SENTRY_URL', None)
-SLACK_API_TOKEN = os.environ.get('SLACK_API_TOKEN', None)
-SLACK_VERIFICATION_TOKEN = os.environ.get('SLACK_VERIFICATION_TOKEN', None)
-SLACK_SIGNING_SECRET = os.environ.get('SLACK_SIGNING_SECRET', None)
 
-RABBITMQ_URL = os.environ.get('RABBITMQ_URL', 'amqp://guest:guest@rabbitmq:5672/%2F')
+def _env(*args, **kwargs):
+    return os.environ.get(*args, **kwargs)
 
 
-def get_slack_webhook_tokens(verification_token, webhook_tokens_string):
+API_KEY = _env('KIZUNA_API_KEY', None)
+DATABASE_URL = _env('DATABASE_URL', 'postgresql://kaori:kaori@db:5432/kaori')
+KIZUNA_ENV = _env('KIZUNA_ENV', 'development')
+KIZUNA_HOME_CHANNEL = _env('KIZUNA_HOME_CHANNEL', '#kaori-home')
+MAIN_CHANNEL = _env('MAIN_CHANNEL', '#banter')
+SENTRY_URL = _env('SENTRY_URL', None)
+SLACK_API_TOKEN = _env('SLACK_API_TOKEN', None)
+SLACK_VERIFICATION_TOKEN = _env('SLACK_VERIFICATION_TOKEN', None)
+SLACK_SIGNING_SECRET = _env('SLACK_SIGNING_SECRET', None)
+
+RABBITMQ_URL = _env('RABBITMQ_URL', 'amqp://guest:guest@rabbitmq:5672/%2F')
+
+
+def _get_slack_webhook_tokens(verification_token, webhook_tokens_string):
     tokens = [verification_token]
     if not webhook_tokens_string:
         return tokens
@@ -22,5 +27,5 @@ def get_slack_webhook_tokens(verification_token, webhook_tokens_string):
     return tokens + webhook_tokens
 
 
-SLACK_WEBHOOK_TOKENS = get_slack_webhook_tokens(SLACK_VERIFICATION_TOKEN,
-                                                os.environ.get('SLACK_WEBHOOK_TOKENS', None))
+SLACK_WEBHOOK_TOKENS = _get_slack_webhook_tokens(SLACK_VERIFICATION_TOKEN,
+                                                 _env('SLACK_WEBHOOK_TOKENS', None))

--- a/config/kaori_test.py
+++ b/config/kaori_test.py
@@ -1,0 +1,1 @@
+from .kaori import *

--- a/kaori/__init__.py
+++ b/kaori/__init__.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+from .support.config import get_config
+
+_test_config_path = Path(__file__).parent.joinpath('../config/kaori_test.py').absolute()
+test_config = get_config(str(_test_config_path))
+
+__all__ = ['test_config']

--- a/kaori/support/config.py
+++ b/kaori/support/config.py
@@ -1,0 +1,11 @@
+from functools import lru_cache
+import importlib.util
+
+# TODO: get_config should probably return a standardized config class
+@lru_cache(maxsize=32)
+def get_config(path):
+    spec = importlib.util.spec_from_file_location("config.kaori", path)
+    config = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(config)
+
+    return config

--- a/kaori/worker/__init__.py
+++ b/kaori/worker/__init__.py
@@ -18,14 +18,11 @@ import kaori.plugins.users
 from kaori.adapters.slack import SlackAdapter
 from kaori.skills import DB
 from kaori.support import Kaori
+from kaori.support.config import get_config
 
 logging.basicConfig(level=logging.DEBUG)
 
-# DEV_INFO = read_dev_info('./.dev-info.json')
-
-spec = importlib.util.spec_from_file_location("config.kaori", os.path.join(os.getcwd(), 'config/kaori.py'))
-config = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(config)
+config = get_config(os.path.join(os.getcwd(), 'config/kaori.py'))
 
 sentry = Client(config.SENTRY_URL,
                 # release=DEV_INFO.get('revision'),


### PR DESCRIPTION
the test specific config (`kaori_test.py`) is used in places like https://github.com/austinpray/kaori/pull/66 to override the regular config values. It also makes it convenient to grab standalone config values

I named the function "get_config" but it should prolly be "eval_config" tbh

To see this in action refer to https://github.com/austinpray/kaori/pull/91