### PR TITLE
Fixes gcloud docker-compose credential issues in build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:
+        version: '297.0.1'
         project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
         service_account_key: ${{secrets.GOOGLE_APPLICATION_CREDENTIALS}}
         export_default_credentials: true


### PR DESCRIPTION
Last known good build https://github.com/austinpray/kaori/runs/793929715?check_suite_focus=true

failing build: https://github.com/austinpray/kaori/runs/814542594?check_suite_focus=true#step:6:141

```
docker.errors.DockerException: Credentials store error: StoreError('Credentials store docker-credential-gcloud exited with "".')
```