### PR TITLE
Support for slugs with words longer than 63 chars long

### DIFF
--- a/kaori/plugins/gacha/models/Card.py
+++ b/kaori/plugins/gacha/models/Card.py
@@ -86,7 +86,9 @@ class Card(Base):
 
     @staticmethod
     def sluggify_name(name: str) -> str:
-        # oof: using idna was a mistake, it's limited to 63 character chunks
+        # TODO: oof: using idna was a mistake, it's limited to 63 character chunks
+        # this is gonna cause undefined behavior at the chunk boundaries.
+        # also good luck generating n-grams for search.
         parts = [
             ''.join([
                 chunk.encode('idna').decode('utf-8')

--- a/kaori/plugins/gacha/models/Card.py
+++ b/kaori/plugins/gacha/models/Card.py
@@ -86,7 +86,15 @@ class Card(Base):
 
     @staticmethod
     def sluggify_name(name: str) -> str:
-        return '-'.join(name.strip().split()).lower().encode('idna').decode('utf-8')
+        # oof: using idna was a mistake, it's limited to 63 character chunks
+        parts = [
+            ''.join([
+                chunk.encode('idna').decode('utf-8')
+                for chunk in re.findall(r'.{1,63}', part)
+            ])
+            for part in name.strip().split()
+        ]
+        return '-'.join(parts).lower()
 
     # todo: too complicated
     @staticmethod

--- a/kaori/plugins/gacha/models/Card.py
+++ b/kaori/plugins/gacha/models/Card.py
@@ -87,7 +87,7 @@ class Card(Base):
     @staticmethod
     def sluggify_name(name: str) -> str:
         # TODO: oof: using idna was a mistake, it's limited to 63 character chunks
-        # this is gonna cause undefined behavior at the chunk boundaries.
+        # this is gonna cause undefined behavior at the chunk boundaries with multibyte characters.
         # also good luck generating n-grams for search.
         parts = [
             ''.join([

--- a/kaori/plugins/gacha/models/test_card.py
+++ b/kaori/plugins/gacha/models/test_card.py
@@ -16,5 +16,8 @@ def test_sluggify():
 
     assert Card.sluggify_name('👩🏿‍🍳') == 'xn--qj8hxirk'
 
+    # note that this test case is basically undefined behavior
+    # assert Card.sluggify_name('👩🏿‍🍳'*50) == ''
+
     assert Card.sluggify_name('Iñtërnâtiônàlizætiøn☃💪') == 'xn--itrntinliztin-vdb0a5exd8ewcyey495hncp2g'
 

--- a/kaori/plugins/gacha/models/test_card.py
+++ b/kaori/plugins/gacha/models/test_card.py
@@ -1,0 +1,20 @@
+from .Card import Card
+
+
+def test_sluggify():
+    assert Card.sluggify_name('') == ''
+    assert Card.sluggify_name('Austin Pray') == 'austin-pray'
+
+    a100 = 'a'*100
+    assert Card.sluggify_name(a100) == a100
+    assert Card.sluggify_name(a100.upper()) == a100
+
+    r = 'Rhoshandiatellyneshiaunneveshenk '*100
+    r_exp = '-'.join(['rhoshandiatellyneshiaunneveshenk']*100)
+
+    assert Card.sluggify_name(r) == r_exp
+
+    assert Card.sluggify_name('👩🏿‍🍳') == 'xn--qj8hxirk'
+
+    assert Card.sluggify_name('Iñtërnâtiônàlizætiøn☃💪') == 'xn--itrntinliztin-vdb0a5exd8ewcyey495hncp2g'
+


### PR DESCRIPTION
**before:** making a card with a name like `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` would fail because idna can only encode 63 characters at a time

**now:** it works

This basically exposed that it was a pretty bad idea to use idna encoding to get a slug. This is gonna run into beaucoup undefined behavior with weird multibyte input. Slack mostly insulates us from these edge cases in production: but I want it to be handled outright by our first-party code in the future.