### PR TITLE
Heatmap correctly represents combinations now

### DIFF
--- a/kaori/conftest.py
+++ b/kaori/conftest.py
@@ -6,11 +6,11 @@ from unittest.mock import Mock, MagicMock
 from uuid import uuid4
 
 import pytest
-from kaori.plugins.users import User
 from slackclient import SlackClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
+from kaori.plugins.users import User
 from .adapters.slack import SlackMessage, SlackAdapter
 from .skills import DB
 
@@ -84,6 +84,24 @@ def fake_user(test_db: DB) -> User:
         session.commit()
 
         return u
+
+
+@pytest.fixture()
+def make_fake_user(test_db: DB) -> callable:
+    def make_user():
+        with test_db.session_scope() as session:
+            name = str(uuid4())
+
+            u = User(name=f'{name}-user',
+                     slack_id=f'{name}-slack-id',
+                     api_key=str(uuid4()))
+
+            session.add(u)
+            session.commit()
+
+            return u
+
+    return make_user
 
 
 _project_root = Path(__file__).parent.parent

--- a/kaori/plugins/gacha/analysis/natures.py
+++ b/kaori/plugins/gacha/analysis/natures.py
@@ -40,6 +40,8 @@ def natures_heatmap(matrix: nature_matrix, ts=datetime.now()):
     fig, ax = plt.subplots()
     hm = sns.heatmap(df.pivot('n1', 'n2', 'count'), annot=True, ax=ax)
 
+    ax.set(xlabel='', ylabel='')
+
     hm.set_title(f'Nature Combinations Heatmap ({ts.strftime("%Y-%m-%d")})')
 
     return hm.get_figure()

--- a/kaori/plugins/gacha/analysis/natures.py
+++ b/kaori/plugins/gacha/analysis/natures.py
@@ -1,6 +1,7 @@
-from typing import List, Dict
+from typing import List, Dict, Tuple
 import matplotlib.pyplot as plt
 from datetime import datetime
+import itertools
 
 from kaori.plugins.gacha.engine import NatureName
 
@@ -9,14 +10,18 @@ from pandas import DataFrame
 
 import seaborn as sns
 
-nature_matrix = Dict[NatureName, Dict[NatureName, int]]
+nature_matrix = Dict[Tuple[str, ...], int]
+
+
+def _make_key(combo):
+    return tuple(sorted(combo))
 
 
 def _make_nature_dict() -> nature_matrix:
+    combinations = itertools.combinations([str(n) for n in NatureName], 2)
+
     return {
-        n: {
-            n: 0 for n in NatureName
-        } for n in NatureName
+        _make_key(combo): 0 for combo in combinations
     }
 
 
@@ -24,15 +29,16 @@ def get_nature_matrix(cards: List[GameCard]) -> nature_matrix:
     matrix = _make_nature_dict()
 
     for card in cards:
-        matrix[card.nature[0]][card.nature[1]] += 1
+        key = _make_key((str(n) for n in card.nature))
+        matrix[key] += 1
 
     return matrix
 
 
 def natures_heatmap(matrix: nature_matrix, ts=datetime.now()):
-    df = DataFrame(matrix)
+    df = DataFrame([[*k, v] for k, v in matrix.items()], columns=['n1', 'n2', 'count'])
     fig, ax = plt.subplots()
-    hm = sns.heatmap(df, annot=True, ax=ax)
+    hm = sns.heatmap(df.pivot('n1', 'n2', 'count'), annot=True, ax=ax)
 
     hm.set_title(f'Nature Combinations Heatmap ({ts.strftime("%Y-%m-%d")})')
 

--- a/kaori/plugins/gacha/analysis/test_analysis.py
+++ b/kaori/plugins/gacha/analysis/test_analysis.py
@@ -1,9 +1,11 @@
 from pandas import DataFrame
 
 from kaori.plugins.gacha.engine import NatureName, RarityName
+from kaori.plugins.gacha.engine.core import Card as GameCard
 
 from .natures import get_nature_matrix, natures_heatmap
 from pathlib import Path
+from uuid import uuid4
 
 from .rarity import get_rarity_dist, rarity_histogram
 
@@ -15,8 +17,7 @@ def test_analysis(project_tmp: Path):
 
     matrix = get_nature_matrix(data)
 
-    assert matrix[NatureName.stupid][NatureName.stupid] == 0
-    assert matrix[NatureName.feral][NatureName.cursed] == 2
+    assert matrix[('cursed', 'feral')] == 2
 
     hm = natures_heatmap(matrix)
 
@@ -30,3 +31,13 @@ def test_analysis(project_tmp: Path):
     hist = rarity_histogram(rdist)
 
     hist.savefig(str(project_tmp.joinpath('test-rarity-breakdown.png')))
+
+    nature_matrix = get_nature_matrix([
+        GameCard(name=str(uuid4()), rarity=RarityName.S, nature=(NatureName.cursed, NatureName.clown)),
+        GameCard(name=str(uuid4()), rarity=RarityName.S, nature=(NatureName.clown, NatureName.cursed)),
+        GameCard(name=str(uuid4()), rarity=RarityName.S, nature=(NatureName.stupid, NatureName.clown)),
+    ])
+
+    hm = natures_heatmap(nature_matrix)
+
+    hm.savefig(str(project_tmp.joinpath('test-reduced-natures-breakdown.png')))

--- a/kaori/plugins/gacha/commands/analysis.py
+++ b/kaori/plugins/gacha/commands/analysis.py
@@ -7,9 +7,9 @@ from typing.io import IO
 from kaori.adapters.slack import SlackCommand, SlackMessage, SlackAdapter
 from kaori.plugins.gacha.analysis import rarity_histogram, get_rarity_dist, natures_heatmap, get_nature_matrix
 from kaori.plugins.gacha.engine.core.card import Card as GameCard
-from kaori.plugins.gacha.models.Card import Card
 from kaori.plugins.gacha.tui import card_stats_blocks
 from kaori.skills import DB
+from kaori.plugins.gacha.models.Card import get_game_cards
 
 
 def generate_report_charts(game_cards: List[GameCard]) -> Dict[str, IO]:
@@ -51,15 +51,11 @@ class CardStatsCommand(SlackCommand):
 
         with db.session_scope() as session:
 
-            cards = session.query(Card) \
-                .filter(Card.published == True) \
-                .all()
+            game_cards = get_game_cards(session)
 
-            if not cards:
+            if not game_cards:
                 bot.reply(message, "No cards", create_thread=True)
                 return
-
-            game_cards: List[GameCard] = [card.engine for card in cards]
 
         bot.reply(message,
                   blocks=card_stats_blocks(card_total=len(game_cards)),

--- a/kaori/plugins/gacha/commands/test_analysis.py
+++ b/kaori/plugins/gacha/commands/test_analysis.py
@@ -1,5 +1,7 @@
-from .analysis import generate_report_charts
 import os
+
+from .analysis import generate_report_charts
+
 
 def test_report():
     from ..engine.test.cards import sachiko, matt_morgan, ubu, xss, balanced_S, low_dmg
@@ -13,6 +15,3 @@ def test_report():
 
     assert report['rarity'].tell() > 0
     assert report['natures'].tell() > 0
-
-
-

--- a/kaori/plugins/gacha/models/Card.py
+++ b/kaori/plugins/gacha/models/Card.py
@@ -8,6 +8,7 @@ import sqlalchemy.orm
 from sqlalchemy.orm import Session
 
 from kaori.support.models.Models import Base
+from ..engine import Card as GameCard
 from ..engine.core import RarityName, Card as EngineCard, NatureName
 
 
@@ -193,3 +194,14 @@ class Card(Base):
 
     def __repr__(self):
         return f"<Card(id='{self.id}', name='{self.name}' owner='{self.owner}')>"
+
+
+def get_game_cards(session: Session) -> List[GameCard]:
+    cards = session.query(Card) \
+        .filter(Card.published == True) \
+        .all()
+
+    if not cards:
+        return []
+
+    return [card.engine for card in cards if card.engine]

--- a/kaori/plugins/gacha/models/Card.py
+++ b/kaori/plugins/gacha/models/Card.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Tuple, Optional, Dict, List
+from typing import Tuple, Optional, Dict, List, Union
 
 import sqlalchemy as sa
 import sqlalchemy.orm
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from kaori.support.models.Models import Base
 from ..engine import Card as GameCard
 from ..engine.core import RarityName, Card as EngineCard, NatureName
+from ...users import User
 
 
 class InvalidCardName(RuntimeError):
@@ -196,10 +197,25 @@ class Card(Base):
         return f"<Card(id='{self.id}', name='{self.name}' owner='{self.owner}')>"
 
 
-def get_game_cards(session: Session) -> List[GameCard]:
-    cards = session.query(Card) \
-        .filter(Card.published == True) \
-        .all()
+_user_identity = Union[User, int]
+
+
+def get_game_cards(session: Session,
+                   user: _user_identity = None,
+                   user_slack_id: str = None) -> List[GameCard]:
+    cards = session.query(Card).join(User).filter(Card.published == True)
+
+    if user:
+        if isinstance(user, User):
+            cards = cards.filter(User.id == user.id)
+        elif isinstance(user, int):
+            cards = cards.filter(User.id == user)
+        else:
+            raise ValueError("Don't know how to handle this user param")
+    elif user_slack_id:
+        cards = cards.filter(User.slack_id == user_slack_id)
+
+    cards = cards.all()
 
     if not cards:
         return []

--- a/kaori/plugins/gacha/models/test_card.py
+++ b/kaori/plugins/gacha/models/test_card.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+import pytest
 from sqlalchemy.orm import Session
 
 from kaori.plugins.gacha.engine import RarityName
@@ -96,3 +97,10 @@ def test_get_game_cards(make_fake_user, db_session: Session):
 
     assert uniq1 in [gc.name for gc in game_cards]
     assert uniq2 in [gc.name for gc in game_cards]
+
+    game_cards = get_game_cards(db_session, user_slack_id=str(uuid4()))
+
+    assert not game_cards
+
+    with pytest.raises(ValueError):
+        get_game_cards(db_session, user=str(uuid4()))

--- a/kaori/plugins/gacha/models/test_card.py
+++ b/kaori/plugins/gacha/models/test_card.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+from kaori.plugins.gacha.engine import RarityName
 from sqlalchemy.orm import Session
 
 from .Card import Card, get_game_cards
@@ -56,6 +57,9 @@ def test_get_game_cards(fake_user: User, db_session: Session):
                   secondary_nature='baby',
                   creation_thread_channel=f'ch-{uniq1}',
                   creation_thread_ts=f'ts-{uniq1}')
+
+    card_a.set_rarity(RarityName.S)
+    card_b.set_rarity(RarityName.S)
 
 
     db_session.add(card_a)

--- a/kaori/plugins/gacha/models/test_card.py
+++ b/kaori/plugins/gacha/models/test_card.py
@@ -1,16 +1,21 @@
-from .Card import Card
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from .Card import Card, get_game_cards
+from ...users import User
 
 
 def test_sluggify():
     assert Card.sluggify_name('') == ''
     assert Card.sluggify_name('Austin Pray') == 'austin-pray'
 
-    a100 = 'a'*100
+    a100 = 'a' * 100
     assert Card.sluggify_name(a100) == a100
     assert Card.sluggify_name(a100.upper()) == a100
 
-    r = 'Rhoshandiatellyneshiaunneveshenk '*100
-    r_exp = '-'.join(['rhoshandiatellyneshiaunneveshenk']*100)
+    r = 'Rhoshandiatellyneshiaunneveshenk ' * 100
+    r_exp = '-'.join(['rhoshandiatellyneshiaunneveshenk'] * 100)
 
     assert Card.sluggify_name(r) == r_exp
 
@@ -21,3 +26,45 @@ def test_sluggify():
 
     assert Card.sluggify_name('Iñtërnâtiônàlizætiøn☃💪') == 'xn--itrntinliztin-vdb0a5exd8ewcyey495hncp2g'
 
+
+def test_get_game_cards(fake_user: User, db_session: Session):
+    uniq1 = str(uuid4())
+    uniq2 = str(uuid4())
+    name_a = f'a-{__name__}'
+    name_b = f'b-{__name__}'
+
+    db_session.query(Card).filter(Card.name.in_((name_a, name_b))).delete(synchronize_session=False)
+
+    db_session.commit()
+
+    db_session.add(fake_user)
+
+    card_a = Card(name=uniq2,
+                  slug=uniq2,
+                  owner=fake_user.id,
+                  published=True,
+                  primary_nature='stupid',
+                  secondary_nature='clown',
+                  creation_thread_channel=f'ch-{uniq2}',
+                  creation_thread_ts=f'ts-{uniq2}')
+
+    card_b = Card(name=uniq1,
+                  slug=uniq1,
+                  owner=fake_user.id,
+                  published=True,
+                  primary_nature='stupid',
+                  secondary_nature='baby',
+                  creation_thread_channel=f'ch-{uniq1}',
+                  creation_thread_ts=f'ts-{uniq1}')
+
+
+    db_session.add(card_a)
+    db_session.add(card_b)
+    db_session.commit()
+
+    game_cards = get_game_cards(db_session)
+
+    assert game_cards
+
+    assert uniq1 in [gc.name for gc in game_cards]
+    assert uniq2 in [gc.name for gc in game_cards]

--- a/kaori/plugins/gacha/models/test_models.py
+++ b/kaori/plugins/gacha/models/test_models.py
@@ -1,16 +1,15 @@
 import re
 from pathlib import Path
 from unittest.mock import Mock
+from uuid import uuid4
+
 from sqlalchemy.orm import Session
 
-from kaori.plugins.users import User
-
-from kaori.skills import LocalFileUploader
-
 from kaori.adapters.slack import SlackMessage, SlackAdapter
-from .Image import Image
+from kaori.plugins.users import User
+from kaori.skills import LocalFileUploader
 from .Card import Card
-from uuid import uuid4
+from .Image import Image
 
 
 def test_card_hydration(db_session: Session):
@@ -114,7 +113,6 @@ def test_card_search(fake_user: User, db_session: Session):
 
     db_session.query(Card).filter(Card.name.in_((name_tim, name_time))).delete(synchronize_session=False)
 
-
     db_session.commit()
 
     db_session.add(fake_user)
@@ -136,7 +134,6 @@ def test_card_search(fake_user: User, db_session: Session):
                     creation_thread_ts=f'ts-{uniq1}')
 
     card_tim.set_name(name_tim)
-
 
     db_session.add(card_time)
     db_session.add(card_tim)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3,8 +3,10 @@
 set -ex
 
 cleanup() {
-  docker-compose stop db-test rabbitmq-test
+  docker-compose rm -fsv db-test rabbitmq-test
 }
+
+cleanup
 
 docker-compose up -d db-test rabbitmq-test
 


### PR DESCRIPTION
I made some last minute changes before shipping https://github.com/austinpray/kaori/pull/162 that made combinations not work as expected. That heatmap was incorrectly visualizing permutations.

- [x] remove "n1" and "n2" from axis

## before

![natures-breakdown](https://user-images.githubusercontent.com/2192970/86506811-9a528780-bd98-11ea-9309-e0cb0d89c529.png)

## after

![test-natures-breakdown](https://user-images.githubusercontent.com/2192970/86516887-0c9f8800-bdea-11ea-82bb-e89a5a68e59f.png)


<details>

<summary>Previous versions</summary>

![test-natures-breakdown](https://user-images.githubusercontent.com/2192970/86506810-9a528780-bd98-11ea-8699-b354fa60e85e.png)

</details>